### PR TITLE
Add error-chain.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["LeopoldArkham <leopold.arkham@gmail.com>"]
 [dependencies]
 chrono = "0.3.0"
 pretty_assertions = "0.1.2"
+error-chain = "0.11.0"
 
 [dev-dependencies]
 test-case-derive = "0.1.4"

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use items::*;
+use errors::*;
 
 #[derive(Debug, Clone)]
 pub struct Container {
@@ -16,11 +17,11 @@ impl Container {
         }
     }
 
-    pub fn append<K: Into<Option<Key>>>(&mut self, _key: K, item: Item) -> Result<(), String> {
+    pub fn append<K: Into<Option<Key>>>(&mut self, _key: K, item: Item) -> Result<()> {
         let key = _key.into();
         if let Some(k) = key.clone() {
             if self.map.contains_key(&k) {
-                return Err(format!("Cannot override existing key: {:?}", k));
+                bail!(ErrorKind::DuplicateKey(k.key));
             }
             self.map.insert(k, self.body.len());
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,22 @@
+error_chain! {
+    errors {
+        ParseError(line: usize, col: usize) {
+            description("TOML parse error")
+            display("TOML parse error line {} column {}", line, col)
+        }
+        DuplicateKey(k: String) {
+            description("Duplicate key")
+            display("Duplicate key: {}", k)
+        }
+        MixedArrayTypes {
+            description("Mixed types found in array")
+        }
+        InvalidNumberOrDate {
+            description("Invalid number or date format")
+        }
+        UnexpectedChar(ch: char) {
+            description("Unexpected character")
+            display("Unexpected character: {}", ch)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 #[macro_use]
 extern crate pretty_assertions;
 extern crate chrono;
+#[macro_use]
+extern crate error_chain;
 
 mod tomlchar;
 mod tomldoc;
@@ -12,3 +14,4 @@ mod api;
 mod index;
 mod items;
 mod container;
+mod errors;

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -40,7 +40,7 @@ fn parser<P: AsRef<Path> + Display>(path: P) {
     f.read_to_string(&mut input).expect("Error reading file:");
 
     let mut parser = Molten::parser::Parser::new(&input);
-    let res = parser.parse();
+    let res = parser.parse().unwrap();
 
     // Knobs for debugging
     // let mut f = File::create("tests/res.toml").unwrap();


### PR DESCRIPTION
Here's a preview of what it might look like using error-chain.  

It currently doesn't compute the line/column for the error message.  I'd like to take a crack at showing a non-copying approach that would make it easier to do this.  I think I'll do it in a separate PR.

There are no tests to assert invalid input.  I could start adding these if you decide to go with this.