### PR TITLE
Add support for Travis-CI builds. (Fixes #17)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: rust
+rust:
+  - 1.15.0
+  - stable
+  - beta
+  - nightly
+sudo: false
+before_script:
+  - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
+script:
+  - cargo test
+  - rustdoc --test README.md -L target
+  - test "$TRAVIS_RUST_VERSION" != "1.15.0" && cargo doc --no-deps || echo "skipping cargo doc"
+notifications:
+  email:
+    on_success: never
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,20 @@
 name = "Molten"
 version = "0.1.0"
 authors = ["LeopoldArkham <leopold.arkham@gmail.com>"]
+readme = "README.md"
+repository = "https://github.com/LeopoldArkham/Molten"
+homepage = "https://github.com/LeopoldArkham/Molten"
+description = """
+Molten is a lossless TOML parser that preserves all comments, indentations, 
+whitespace and internal element ordering, and makes all of these fully 
+editable via an easy API. It is written with the intent of replacing the 
+current TOML parser used in cargo-edit, and, eventually, adding that
+functionality to Cargo itself.
+"""
+categories = ["config", "encoding", "parser-implementations"]
+
+[badges]
+travis-ci = { repository = "LeopoldArkham/Molten" }
 
 [dependencies]
 chrono = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Molten
+
+[![Build Status](https://travis-ci.org/LeopoldArkham/Molten.svg?branch=master)](https://travis-ci.org/LeopoldArkham/Molten)
+
 ## [WIP] Molten - Style-preserving TOML parser.
 
-Molten is a WIP lossless TOML parser that preserves all comments, indentations, whitespace and internal element ordering, and makes  all of these fully editable via an easy API.
-It is written with the intent of replacing the current toml parser used in cargo-edit, and, eventually, adding that functionality to cargo itself.
+Molten is a WIP lossless [TOML](https://github.com/toml-lang/toml) parser that preserves all
+comments, indentations, whitespace and internal element ordering, and makes all of these fully
+editable via an easy API. It is written with the intent of replacing the current TOML parser
+used in [cargo-edit](https://github.com/killercup/cargo-edit), and, eventually, adding that
+functionality to Cargo itself.
 
 ### Goals
 - Speed: Molten is a one-pass parser which avoids allocation.
@@ -27,5 +33,5 @@ at your option.
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in Serde by you, as defined in the Apache-2.0 license, shall be
+for inclusion in Molten by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
Add Travis-CI build script in .travis.yaml. The script only builds using the
nightly Rust compiler, since the source requires features only available in
nightly. The README.md has a link to the CI build status badge.

NOTE: LeopoldArkham will need to create a Travis CI account and enable the
Github integration for the CI functions to work properly. See the Getting Started
page for details: https://travis-ci.com/getting_started.
    
Add additional meta-data to Cargo.toml, and corrected the reference to
Serde in the license section of the README.md
