### PR TITLE
Add OS-specific newline constant. (Fixes LeopoldArkham/Molten#26)

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -29,7 +29,7 @@ impl<'a> LineMeta<'a> {
             indent: "",
             comment_ws: "",
             comment: "",
-            trail: "\r\n",
+            trail: ::NL,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,3 +21,6 @@ pub use items::*;
 // Should be private and handled via API
 pub mod container;
 pub use container::Container;
+
+#[cfg(windows)] pub const NL: &'static str = "\r\n";
+#[cfg(not(windows))] pub const NL: &'static str = "\n";

--- a/tests/reconstruction.rs
+++ b/tests/reconstruction.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use test_case_derive::test_case;
 use Molten::{TOMLDocument, Container};
 use Molten::items::*;
+use Molten::NL;
 
 // To add a test case:
 // 1) Write a target toml file in /reconstruction
@@ -107,7 +108,7 @@ fn AoTs() -> TOMLDocument<'static> {
 
         let mut nested_container = Container::new();
         let _ = nested_container.append(nested_id_k, nested_id_v);
-        let _ = nested_container.append(None, Item::WS("\r\n"));
+        let _ = nested_container.append(None, Item::WS(::NL));
 
         let nested_k = Key::new("first.nested");
         let nested_v = Item::Table {
@@ -130,7 +131,7 @@ fn AoTs() -> TOMLDocument<'static> {
         let id_k = Key::new("id");
         let id_v = Item::integer("2");
         let _ = _container.append(id_k, id_v);
-        let _ = _container.append(None, Item::WS("\r\n"));
+        let _ = _container.append(None, Item::WS(::NL));
 
         Item::Table {
             is_array: true,
@@ -154,7 +155,7 @@ fn AoTs() -> TOMLDocument<'static> {
         let boolean_v = Item::Bool {val: true, meta: trivia.clone()};
         let mut table_container = Container::new();
         let _ = table_container.append(boolean_k, boolean_v);
-        let _ = table_container.append(None, Item::WS("\r\n"));
+        let _ = table_container.append(None, Item::WS(::NL));
 
 
         let table = Item::Table {


### PR DESCRIPTION
Tests on Linux were failing due to differences in newline handling.
The code assumed Windows-specific newlines (\r\n), but UNIX-based
OSes use single newline characters (\n). Using the NL constant
allows the newline character to change based on the host OS, and
for all the tests to pass.