### PR TITLE
Add documentation to allow #![deny(missing_docs)].

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
-target
+target/
+doc/
 Cargo.lock
 *.rs.bk
+*.rs.fmt
 tests/res.toml
 \.vscode/
+\#*\#
+*\~
 
 *.txt
+*.code-workspace

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,7 @@
 use items::*;
 
 impl<'a> Item<'a> {
+    /// Returns true if Item is a value.
     pub fn is_value(&self) -> bool {
         match self.discriminant() {
             0 | 1 => false,
@@ -8,50 +9,62 @@ impl<'a> Item<'a> {
         }
     }
 
+    /// Returns true if Item is trivia.
     pub fn is_trivia(&self) -> bool {
         !self.is_value()
     }
 
+    /// Returns true if Item is whitespace.
     pub fn is_ws(&self) -> bool {
         self.discriminant() == 0
     }
 
+    /// Returns true if Item is a comment.
     pub fn is_comment(&self) -> bool {
         self.discriminant() == 1
     }
 
+    /// Returns true if Item is an integer.
     pub fn is_integer(&self) -> bool {
         self.discriminant() == 2
     }
 
+    /// Returns true if Item is a float.
     pub fn is_float(&self) -> bool {
         self.discriminant() == 3
     }
 
+    /// Returns true if Item is a boolean.
     pub fn is_bool(&self) -> bool {
         self.discriminant() == 4
     }
 
+    /// Returns true if Item is a date/time.
     pub fn is_date_time(&self) -> bool {
         self.discriminant() == 5
     }
 
+    /// Returns true if Item is an array.
     pub fn is_array(&self) -> bool {
         self.discriminant() == 6
     }
 
+    /// Returns true if Item is a table.
     pub fn is_table(&self) -> bool {
         self.discriminant() == 7 || self.discriminant() == 8
     }
 
+    /// Returns true if Item is an inline table.
     pub fn is_inline_table(&self) -> bool {
         self.discriminant() == 8
     }
 
+    /// Returns true if Item is a string.
     pub fn is_string(&self) -> bool {
         self.discriminant() == 9
     }
 
+    /// Returns true if Item is AOT.
     pub fn is_aot(&self) -> bool {
         self.discriminant() == 10
     }

--- a/src/container.rs
+++ b/src/container.rs
@@ -3,13 +3,15 @@ use std::collections::HashMap;
 use items::*;
 use errors::*;
 
-#[derive(Debug, Clone, PartialEq)]
+/// A container for items within a `TOMLDocument`.
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Container<'a> {
     pub(crate) map: HashMap<Key<'a>, usize>,
     pub(crate) body: Vec<(Option<Key<'a>>, Item<'a>)>,
 }
 
 impl<'a> Container<'a> {
+    /// Create a new empty `Container`.
     pub fn new() -> Container<'a> {
         Container {
             map: HashMap::new(),
@@ -17,6 +19,7 @@ impl<'a> Container<'a> {
         }
     }
 
+    /// Add a key, item pair to the container.
     pub fn append<K: Into<Option<Key<'a>>>>(&mut self, _key: K, item: Item<'a>) -> Result<()> {
         let key = _key.into();
         if let Some(k) = key.clone() {
@@ -30,7 +33,8 @@ impl<'a> Container<'a> {
         Ok(())
     }
 
-    // @cleanup: minimize duplication with Item::as_string()
+    /// Return the string representation of a `Container`.
+    // TODO: minimize duplication with Item::as_string()
     pub fn as_string(&self) -> String {
         let mut s = String::new();
         for (k, v) in self.body.clone().into_iter() {
@@ -89,6 +93,7 @@ impl<'a> Container<'a> {
         s
     }
 
+    /// Return a container iterator.
     pub fn iter(&'a self) -> ContainerIterator<'a> {
         ContainerIterator {
             container: self,
@@ -96,6 +101,7 @@ impl<'a> Container<'a> {
         }
     }
 
+    /// Return an exhauseive container iterator.
     pub fn iter_exhaustive(&self) -> ContainerIteratorExhaustive {
         ContainerIteratorExhaustive {
             container: self,
@@ -104,6 +110,8 @@ impl<'a> Container<'a> {
     }
 }
 
+/// An iterator that returns the items in the container.
+#[derive(Debug)]
 pub struct ContainerIterator<'a> {
     container: &'a Container<'a>,
     current: usize,
@@ -112,7 +120,7 @@ pub struct ContainerIterator<'a> {
 impl<'a> Iterator for ContainerIterator<'a> {
     type Item = &'a Item<'a>;
 
-    // @cleanup: "There must be a better way"
+    // CLEANUP: There must be a better way
     fn next(&mut self) -> Option<&'a Item<'a>> {
         loop {
             if self.current == self.container.body.len() {
@@ -130,6 +138,8 @@ impl<'a> Iterator for ContainerIterator<'a> {
     }
 }
 
+/// An iterator that returns **all** items in the container.
+#[derive(Debug)]
 pub struct ContainerIteratorExhaustive<'a> {
     container: &'a Container<'a>,
     current: usize,

--- a/src/container.rs
+++ b/src/container.rs
@@ -11,7 +11,7 @@ pub struct Container<'a> {
 }
 
 impl<'a> Container<'a> {
-    /// Create a new empty `Container`.
+    /// Creates a new empty `Container`.
     pub fn new() -> Container<'a> {
         Container {
             map: HashMap::new(),
@@ -19,7 +19,7 @@ impl<'a> Container<'a> {
         }
     }
 
-    /// Add a key, item pair to the container.
+    /// Adds a (key, item) pair to the container.
     pub fn append<K: Into<Option<Key<'a>>>>(&mut self, _key: K, item: Item<'a>) -> Result<()> {
         let key = _key.into();
         if let Some(k) = key.clone() {
@@ -33,7 +33,7 @@ impl<'a> Container<'a> {
         Ok(())
     }
 
-    /// Return the string representation of a `Container`.
+    /// Returns the string representation of a `Container`.
     // TODO: minimize duplication with Item::as_string()
     pub fn as_string(&self) -> String {
         let mut s = String::new();
@@ -93,7 +93,7 @@ impl<'a> Container<'a> {
         s
     }
 
-    /// Return a container iterator.
+    /// Returns a container iterator.
     pub fn iter(&'a self) -> ContainerIterator<'a> {
         ContainerIterator {
             container: self,
@@ -101,7 +101,7 @@ impl<'a> Container<'a> {
         }
     }
 
-    /// Return an exhauseive container iterator.
+    /// Returns an exhauseive container iterator.
     pub fn iter_exhaustive(&self) -> ContainerIteratorExhaustive {
         ContainerIteratorExhaustive {
             container: self,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -47,7 +47,7 @@ error_chain! {
             description("Internal Parser Error")
             display("{}\n The parser has violated one of its invariants.
             This is a bug.\n
-            Please open an issue uqoting this message at
+            Please open an issue citing this message at
             https://github.com/LeopoldArkham/Molten", msg)
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,30 +1,48 @@
 error_chain! {
     errors {
+
+        /// This error occurs when the parser encounters a syntax error
+        /// in the TOML being parsed. The error references the line and
+        /// location within the line where the error was encountered.
         ParseError(line: usize, col: usize) {
             description("TOML parse error")
             display("TOML parse error line {} column {}", line, col)
         }
+
+        /// A duplicate key was found.
         DuplicateKey(k: String) {
             description("Duplicate key")
             display("Duplicate key: {}", k)
         }
+
+        /// An array was found that had two or more element types.
         MixedArrayTypes {
             description("Mixed types found in array")
         }
+
+        /// A numeric or date field was improperly specified.
         InvalidNumberOrDate {
             description("Invalid number or date format")
         }
+
+        /// An unexpected character was found during parsing.
         UnexpectedChar(ch: char) {
             description("Unexpected character")
             display("Unexpected character: {}", ch)
         }
+
+        /// The TOML being parsed ended before the end of a statement.
         UnexpectedEof {
             description("Unepxected end of file")
         }
+
+        /// The string being parsed contains an invalid character.
         InvalidCharInString(ch: char) {
             description("Invalid character in string")
             display("Invalid character '{}' in string", ch) // XXX escaping
         }
+
+        /// An error that indicates a bug in the parser.
         InternalParserError(msg: String) {
             description("Internal Parser Error")
             display("{}\n The parser has violated one of its invariants.

--- a/src/index.rs
+++ b/src/index.rs
@@ -20,7 +20,7 @@ impl<'a> Index<usize> for TOMLDocument<'a> {
     type Output = Item<'a>;
 
     fn index(&self, idx: usize) -> &Self::Output {
-        // XXX TODO
+        // XXX TODO:
         &self.0.body[idx].1
         // self.0.iter().nth(idx).expect("Indexing TOMLDoc failed")
     }
@@ -33,7 +33,7 @@ impl<'a> Index<usize> for Item<'a> {
         use self::Item::*;
         match *self {
             Array { ref val, .. } => &val[idx],
-            // XXX TODO
+            // XXX TODO:
             // Table { ref val, .. } => &val.iter().nth(idx).expect("Indexing Table failed"),
             // InlineTable { ref val, .. } => {
             //     &val.iter().nth(idx).expect("Indexing InlineTable failed")

--- a/src/items.rs
+++ b/src/items.rs
@@ -1,15 +1,66 @@
-
 use chrono::{DateTime as ChronoDateTime, FixedOffset};
 use container::Container;
 
+/// Type of TOML string.
+///
+/// There are four ways to express strings: basic, multi-line basic, 
+/// literal, and multi-line literal. All strings must contain only valid UTF-8 
+/// characters.
+///
+/// **Basic strings** are surrounded by quotation marks. Any Unicode 
+/// character may be used except those that must be escaped: quotation mark,
+/// backslash, and the control characters (U+0000 to U+001F).
+///
+/// ```text
+/// str = "I'm a string. \"You can quote me\". Name\tJos\u00E9\nLocation\tSF."
+/// ```
+///
+/// For convenience, common characters have a compact escape sequence.
+/// 
+/// | Escape       | Name            | Unicode Replacement |
+/// |--------------|-----------------|---------------------|
+/// | \b           | backspace       | (U+0008)            |
+/// | \t           | tab             | (U+0009)            |
+/// | \n           | linefeed        | (U+000A)            |
+/// | \f           | form feed       | (U+000C)            |
+/// | \r           | carriage return | (U+000D)            |
+/// | \"           | quote           | (U+0022)            |
+/// | \\           | backslash       | (U+005C)            |
+/// | `\uXXXX`     | unicode         | (U+XXXX)            |
+/// | `\UXXXXXXXX` | unicode         | (U+XXXXXXXX)        |
+///
+/// Any Unicode character may be escaped with the `\uXXXX` or `\UXXXXXXXX`
+/// forms. The escape codes must be valid Unicode scalar values.
+/// 
+/// All other escape sequences not listed above are reserved and, if used, 
+/// should produce an error.
+///
+/// **Multi-line basic** strings are surrounded by three quotation marks on 
+/// each side and allow newlines. A newline immediately following the opening
+/// delimiter will be trimmed. All other whitespace and newline characters
+/// remain intact.
+///
+/// **Literal strings** are surrounded by single quotes. Like basic strings,
+/// they must appear on a single line. Literal strings do not allow escaping
+/// of characters within the string.
+///
+/// **Multi-line literal** strings are surrounded by three single-quotes on 
+/// each side and allow newlines. A newline immediately following the opening
+/// delimiter will be trimmed. All other whitespace and newline characters
+/// remain intact. No escaping is allowed within the string.
 #[derive(Debug, Clone, PartialEq)]
 pub enum StringType {
+    /// Single line basic string.
     SLB,
+    /// Multi-line basic string.
     MLB,
+    /// Single-line literal string.
     SLL,
+    /// Multi-line literal string.
     MLL,
 }
 
+/// Trivia information (aka metadata).
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Trivia<'a> {
     /// Whitespace before a value.
@@ -34,20 +85,26 @@ impl<'a> Trivia<'a> {
     }
 }
 
-#[derive(Debug, Hash, PartialEq, Eq, Clone)]
 /// The type of a key.
-/// Keys can be bare or follow the same rules as
-/// either string type.
+/// Keys can be bare or follow the same rules as either string type.
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub enum KeyType {
+    /// Bare key.
     Bare,
+    /// Basic key.
     Basic,
+    /// Literal key.
     Literal,
 }
 
+/// A key value.
 #[derive(Hash, Clone)]
 pub struct Key<'a> {
+    /// The type of the key
     pub t: KeyType,
+    /// The key separator
     pub sep: &'a str,
+    /// The actual key value
     pub key: &'a str,
 }
 
@@ -77,6 +134,7 @@ impl<'a> ::std::fmt::Debug for Key<'a> {
 }
 
 impl<'a> Key<'a> {
+    /// Return the string represenation of a `Key`.
     pub fn as_string(&self) -> String {
         let quote = match self.t {
             KeyType::Bare => "",
@@ -88,49 +146,87 @@ impl<'a> Key<'a> {
     }
 }
 
+/// An item within a TOML document.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Item<'a> {
+    /// A whitespace literal.
     WS(&'a str),
+    /// A comment literal.
     Comment(Trivia<'a>),
+    /// An integer literal.
     Integer {
+        /// The value of the integer.
         val: i64,
+        /// Trivia for the integer.
         meta: Trivia<'a>,
+        /// The original representation of the integer value.
         raw: &'a str,
     },
+    /// A float literal.
     Float {
+        /// The value of the float.
         val: f64,
+        /// Trivia data for the Float.
         meta: Trivia<'a>,
+        /// The original string representation of the value.
         raw: &'a str,
     },
-    Bool { val: bool, meta: Trivia<'a> },
+    /// A bool literal.
+    Bool { 
+        /// The value of the boolean.
+        val: bool, 
+        /// Trivia data for the boolean.
+        meta: Trivia<'a> 
+    },
+    /// A datetime literal.
     DateTime {
+        /// The value of the date/time.
         val: ChronoDateTime<FixedOffset>,
+        /// The original string representation of the value.
         raw: &'a str,
+        /// Trivia data for the datetime value.
         meta: Trivia<'a>,
     },
+    /// An array literal.
     Array {
+        /// The contents of the array.
         val: Vec<Item<'a>>,
+        /// Trivia data for the array.
         meta: Trivia<'a>,
     },
+    /// A table literal.
     Table {
+        /// `true` if the table is an array.
         is_array: bool,
+        /// The contents of the table.
         val: Container<'a>,
+        /// Triva data for the table.
         meta: Trivia<'a>,
     },
+    /// An inline table literal.
     InlineTable {
+        /// The contents of the table.
         val: Container<'a>,
+        /// Triva data for the table.
         meta: Trivia<'a>,
     },
+    /// A string literal.
     Str {
+        /// The type of string this represents
         t: StringType,
-        val: &'a str, // TODO, make Cow
+        /// The straing value
+        val: &'a str, // TODO:, make Cow
+        /// Original string value, including any decoration
         original: &'a str,
+        /// Trivia data for the string
         meta: Trivia<'a>,
     },
+    /// An AoT literal.
     AoT(Vec<Item<'a>>),
 }
 
 impl<'a> Item<'a> {
+    /// Returns a unique integer that represents the type of the `Item`.
     pub fn discriminant(&self) -> i32 {
         use self::Item::*;
         match *self {
@@ -167,6 +263,7 @@ impl<'a> Item<'a> {
         }
     }
 
+    /// Returns the string representation of an `Item`.
     pub fn as_string(&self) -> String {
         use self::Item::*;
         match *self {
@@ -227,6 +324,7 @@ impl<'a> Item<'a> {
         }
     }
 
+    /// Return a `Trivia`.
     pub fn meta(&self) -> &Trivia<'a> {
         use self::Item::*;
         match *self {
@@ -245,6 +343,7 @@ impl<'a> Item<'a> {
         }
     }
 
+    /// Return a mutabile `Trivia`.
     pub fn meta_mut(&mut self) -> &mut Trivia<'a> {
         use self::Item::*;
         match *self {

--- a/src/items.rs
+++ b/src/items.rs
@@ -134,7 +134,7 @@ impl<'a> ::std::fmt::Debug for Key<'a> {
 }
 
 impl<'a> Key<'a> {
-    /// Return the string represenation of a `Key`.
+    /// Returns the string represenation of a `Key`.
     pub fn as_string(&self) -> String {
         let quote = match self.t {
             KeyType::Bare => "",
@@ -196,7 +196,7 @@ pub enum Item<'a> {
     },
     /// A table literal.
     Table {
-        /// `true` if the table is an array.
+        /// `true` if the table is a member of an AoT.
         is_array: bool,
         /// The contents of the table.
         val: Container<'a>,
@@ -214,8 +214,8 @@ pub enum Item<'a> {
     Str {
         /// The type of string this represents
         t: StringType,
-        /// The straing value
-        val: &'a str, // TODO:, make Cow
+        /// The string value
+        val: &'a str, // TODO: make Cow
         /// Original string value, including any decoration
         original: &'a str,
         /// Trivia data for the string
@@ -324,7 +324,7 @@ impl<'a> Item<'a> {
         }
     }
 
-    /// Return a `Trivia`.
+    /// Returns a `Trivia`.
     pub fn meta(&self) -> &Trivia<'a> {
         use self::Item::*;
         match *self {
@@ -343,7 +343,7 @@ impl<'a> Item<'a> {
         }
     }
 
-    /// Return a mutabile `Trivia`.
+    /// Returns a mutable `Trivia`.
     pub fn meta_mut(&mut self) -> &mut Trivia<'a> {
         use self::Item::*;
         match *self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,56 @@
+/*! 
+Molten is a lossless TOML parser that preserves all comments, indentations, 
+whitespace and internal element ordering, and makes all of these fully 
+editable via an easy API. It is written with the intent of replacing the 
+current TOML parser used in [cargo-edit](https://github.com/killercup/cargo-edit),
+and, eventually, adding that functionality to 
+[cargo](https://github.com/rust-lang/cargo) itself.
+
+## Goals
+
+- *Speed*: Molten is a one-pass parser which avoids allocation.
+- *Unopinionated*: Molten respects the way you wrote your document, to the letter.
+- *Fully addressable*: All TOML elements can be edited, created, or deleted via the API.
+
+## Non-Goals
+- *Error recovery*: Molten does not try to correct recoverable errors.
+- *Serialization/Deserialization*: See [toml-rs](https://github.com/alexcrichton/toml-rs) for this.
+
+
+# Setup
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+molten = "1.0.0"
+```
+
+and this to your crate root:
+
+```text
+extern crate Molten;
+```
+
+# Example
+
+Here is a example of using Molten to parse a trivial TOML document:
+
+```rust
+let toml = String::from("bool = true\nstring = \"Hello!\"\nint = 42");
+let parsed = {
+    let mut parser = Molten::parser::Parser::new(&toml);
+    parser.parse().unwrap()
+};
+
+assert_eq!(toml, parsed.as_string());
+```
+*/
+
+// #![warn(missing_docs)]
 #![allow(non_snake_case)]
-#[allow(unused_imports)]
-#[macro_use]
+//#[allow(unused_imports)]
+//#[macro_use]
 extern crate pretty_assertions;
 extern crate chrono;
 #[macro_use]
@@ -14,13 +64,17 @@ pub mod api;
 pub mod index;
 pub mod items;
 
+#[doc(inline)]
 pub use tomldoc::TOMLDocument;
+#[doc(inline)]
 pub use items::*;
 
 // Only public as a hack for testing;
 // Should be private and handled via API
+#[doc(inline)]
 pub mod container;
+#[doc(inline)]
 pub use container::Container;
 
-#[cfg(windows)] pub const NL: &'static str = "\r\n";
-#[cfg(not(windows))] pub const NL: &'static str = "\n";
+/// Line terminator constant.
+pub const NL: &str = "\n";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ assert_eq!(toml, parsed.as_string());
 // #![warn(missing_docs)]
 #![allow(non_snake_case)]
 //#[allow(unused_imports)]
-//#[macro_use]
+
 extern crate pretty_assertions;
 extern crate chrono;
 #[macro_use]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,10 +8,11 @@ use chrono::DateTime as ChronoDateTime;
 
 use std::str::{FromStr, CharIndices};
 
-// Allowing dead code due to https://github.com/rust-lang/rust/issues/18290
+// FIXME: Allowing dead code due to https://github.com/rust-lang/rust/issues/18290
 #[allow(non_camel_case_types, dead_code)]
 type isAOT = bool;
 
+/// Parser for TOML documents.
 #[derive(Debug)]
 pub struct Parser<'a> {
     /// Input to parse.
@@ -52,7 +53,8 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Dirty hack that should go away
+    // HACK: this should go away
+    /// Extract the exact value between marker and index.
     fn extract_exact(&mut self) -> &'a str {
         &self.src[self.marker..self.idx]
     }
@@ -86,7 +88,7 @@ impl<'a> Parser<'a> {
 
     /// Create error at the current position.
     fn parse_error(&self) -> Error {
-        // @todo: Actually report position of error (#14)
+        // TODO: Actually report position of error (#14)
         let (line, col) = (0, 0);
         ErrorKind::ParseError(line, col).into()
     }
@@ -132,9 +134,9 @@ impl<'a> Parser<'a> {
         loop {
             match self.current {
                 // Found a newline; Return all whitespace found up to this point.
-                // @todo: merge consecutive WS
+                // TODO: merge consecutive WS
                 '\n' => {
-                    self.inc(); // TODO eof
+                    self.inc(); // TODO: eof
                     return Ok(Some((None, Item::WS(self.extract()))));
                 }
                 // Skip whitespace.
@@ -349,7 +351,7 @@ impl<'a> Parser<'a> {
             '+' | '-' | '0'...'9' => {
                 while self.current.not_in(" \t\n\r#,]}") && self.inc() {}
 
-                // TODO EOF shittiness
+                // TODO: EOF shittiness
                 // if !self.current.is_digit(10) {
                 //     self.idx -= 1;
                 // }
@@ -368,7 +370,7 @@ impl<'a> Parser<'a> {
                         raw: raw,
                     });
                 } else if let Ok(res) = f64::from_str(&clean) {
-                    // @incomplete: "Similar to integers, you may use underscores to enhance
+                    // TODO: "Similar to integers, you may use underscores to enhance
                     // readability. Each underscore must be surrounded by at least one digit."
                     return Ok(Item::Float {
                         val: res,
@@ -438,7 +440,7 @@ impl<'a> Parser<'a> {
                             // Not a triple quote, leave in result as-is.
                             continue 'outer;
                         }
-                        self.inc(); // TODO Handle EOF
+                        self.inc(); // TODO: Handle EOF
                     }
                 } else {
                     self.inc();
@@ -511,7 +513,7 @@ impl<'a> Parser<'a> {
         let current = self.current;
         let marker = self.marker;
 
-        // @fixme: May need changing to allow leading indentation
+        // FIXME: May need changing to allow leading indentation
         if self.current != '[' {
             bail!(ErrorKind::InternalParserError(
                 "Peek_table_name entered on non-bracket character".into(),
@@ -542,6 +544,7 @@ impl<'a> Parser<'a> {
         Ok((is_AOT, table_name))
     }
 
+    /// Parse a table element.
     pub fn parse_table(&mut self) -> Result<(Key<'a>, Item<'a>)> {
         let indent = self.extract();
         self.inc(); // Skip opening bracket.
@@ -554,7 +557,7 @@ impl<'a> Parser<'a> {
 
         // Key
         self.mark();
-        // TODO, handle EOF.
+        // TODO:, handle EOF.
         while self.current != ']' && self.inc() {}
 
         // TODO: Key parsing and validation.
@@ -573,10 +576,10 @@ impl<'a> Parser<'a> {
 
         let (cws, comment, trail) = self.parse_comment_trail();
 
-        // @cleanup: Total hack, add undecided variant
+        // CLEANUP: Total hack, add undecided variant
         let mut result = Item::integer("999");
         let mut values = Container::new();
-        // @cleanup: Wait for table API:
+        // CLEANUP: Wait for table API:
         // Use table API to add kv's as they come so result is never
         // uninitialized
         while !self.end() {
@@ -615,7 +618,7 @@ impl<'a> Parser<'a> {
                 }
             }
         }
-        // @cleanup: undecided variant
+        // CLEANUP: undecided variant
         if result.is_integer() {
             result = Item::Table {
                 is_array: is_aot,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -30,7 +30,7 @@ pub struct Parser<'a> {
 }
 
 impl<'a> Parser<'a> {
-    /// Create a new parser from a &str.
+    /// Creates a new parser from a &str.
     pub fn new(input: &'a str) -> Parser<'a> {
         let mut p = Parser {
             src: input,
@@ -44,7 +44,7 @@ impl<'a> Parser<'a> {
         p
     }
 
-    /// Extract the value between marker and index.
+    /// Extracts the value between marker and index.
     fn extract(&mut self) -> &'a str {
         if self.end() {
             &self.src[self.marker..]
@@ -54,7 +54,7 @@ impl<'a> Parser<'a> {
     }
 
     // HACK: this should go away
-    /// Extract the exact value between marker and index.
+    /// Extracts the exact value between marker and index.
     fn extract_exact(&mut self) -> &'a str {
         &self.src[self.marker..self.idx]
     }
@@ -86,7 +86,7 @@ impl<'a> Parser<'a> {
         self.marker = self.idx;
     }
 
-    /// Create error at the current position.
+    /// Creates an error at the current position.
     fn parse_error(&self) -> Error {
         // TODO: Actually report position of error (#14)
         let (line, col) = (0, 0);
@@ -351,11 +351,6 @@ impl<'a> Parser<'a> {
             '+' | '-' | '0'...'9' => {
                 while self.current.not_in(" \t\n\r#,]}") && self.inc() {}
 
-                // TODO: EOF shittiness
-                // if !self.current.is_digit(10) {
-                //     self.idx -= 1;
-                // }
-
                 let raw = self.extract();
 
                 let clean: String = raw.chars()
@@ -399,6 +394,7 @@ impl<'a> Parser<'a> {
         self.parse_string('"')
     }
 
+    /// Parses a string element
     fn parse_string(&mut self, delim: char) -> Result<Item<'a>> {
         // TODO: Handle escaping.
         let mut multiline = false;
@@ -524,7 +520,6 @@ impl<'a> Parser<'a> {
         self.inc();
         let is_AOT = match self.current {
             '[' => {
-                println!("AOT");
                 self.inc();
                 true as isAOT
             }
@@ -544,7 +539,7 @@ impl<'a> Parser<'a> {
         Ok((is_AOT, table_name))
     }
 
-    /// Parse a table element.
+    /// Parses a table element.
     pub fn parse_table(&mut self) -> Result<(Key<'a>, Item<'a>)> {
         let indent = self.extract();
         self.inc(); // Skip opening bracket.
@@ -634,8 +629,9 @@ impl<'a> Parser<'a> {
         Ok((key, result))
     }
 
+    /// Parses all siblings of the provided table `first` and
+    /// bundles them into an AoT.
     fn parse_aot(&mut self, first: Item<'a>, name_first: &'a str) -> Result<Item<'a>> {
-        // We are in an AoT, and next is not a child of first.
         let mut payload = vec![first];
         self.AoT_stack.push(name_first);
         while !self.end() {

--- a/src/tomldoc.rs
+++ b/src/tomldoc.rs
@@ -1,9 +1,13 @@
 use container::Container;
 
+/// A TOML document.
+///
+/// This is the container that holds the contents of a TOML file.
 #[derive(Debug, PartialEq)]
 pub struct TOMLDocument<'a>(pub Container<'a>);
 
 impl<'a> TOMLDocument<'a> {
+    /// Return the string reprentation of a `TOMLDocument`.
     pub fn as_string(&self) -> String {
         self.0.as_string()
     }

--- a/tests/reconstruction.rs
+++ b/tests/reconstruction.rs
@@ -41,7 +41,7 @@ lazy_static! {
 #[test_case("tests/reconstruction/simple.toml", "simple" :: "Simple")]
 #[test_case("tests/reconstruction/AoTs.toml", "AoTs" :: "AoT's")]
 /// Constructs a copy of the reference document using the API and 
-/// compares the two TOMLDoc hierarchies.
+/// compares the two `TOMLDocument` hierarchies.
 fn reconstuct<P: AsRef<Path> + Display>(path: P, constructor: &str) {
     let mut reference = String::new();
     let mut f = File::open(&path).unwrap();


### PR DESCRIPTION
Add documentation to all functions, structs, and types to satisfy
the linter when #[deny(missing_docs)] is used. Module-level
documentation is still not included for the internal modules since
it's really redundant at the moment, so #[deny(missing_docs)] is
not currently enabled by default. The documentation for many
functions are quite terse and could use additional information to
make them accessible for end-users of the library.