### PR TITLE
Number parsing: reject invalid underscores

### DIFF
--- a/tests/reproduction/floats.toml
+++ b/tests/reproduction/floats.toml
@@ -1,15 +1,16 @@
 # fractional
-flt1 = +1.0
-flt2 = 3.1415
-flt3 = -0.01
+flt01 = +1.0
+flt02 = 3.1415
+flt03 = -0.01
+flt04 = 0.1
 
 # exponent
-flt4 = 5e+22
-flt5 = 1e6
-flt6 = -2E-2  
+flt10 = 5e+22
+flt11 = 1e6
+flt12 = -2E-2
 
 # both
-flt7 = 6.626e-34
+flt20 = 6.626e-34
 
 # Cheeky space at the end
-flt8 = 9_224_617.445_991_228_313 
+flt30 = 9_224_617.445_991_228_313 


### PR DESCRIPTION
Fix for #10 to accept only valid numbers according to the spec:
> Each underscore must be surrounded by at least one digit.

and
> Leading zeros are not allowed.