### PR TITLE
Remove the dependency on nightly for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: rust
 rust:
+  - stable
+  - beta
   - nightly
+matrix:
+  allow_failures:
+  - rust: nightly
 sudo: false
 before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,4 @@ pretty_assertions = "0.4.0"
 error-chain = "0.11.0"
 
 [dev-dependencies]
-test-case-derive = "0.1.4"
 pretty_assertions = "0.4.0"
-lazy_static = "0.2"

--- a/tests/reconstruction.rs
+++ b/tests/reconstruction.rs
@@ -1,266 +1,273 @@
-#![feature(proc_macro)]
-
 #[macro_use]
 extern crate Molten;
-extern crate test_case_derive;
-#[macro_use]
-extern crate lazy_static;
 #[macro_use]
 extern crate pretty_assertions;
 
-#[allow(unused_imports)]
+//#[allow(unused_imports)]
 use std::io::{Read, Write};
 use std::path::Path;
 use std::fs::File;
 use std::fmt::Display;
-use std::collections::HashMap;
 
-use test_case_derive::test_case;
 use Molten::{TOMLDocument, Container};
 use Molten::items::*;
 use Molten::NL;
 
 // To add a test case:
 // 1) Write a target toml file in /reconstruction
-// 2) Write a function with the same name at the end of this file,
+// 2) Write a public function with the same name inside the `constructors` module (in this file),
 // which programatically reproduces your target document.
-// 3) Add your function to the hashmap below
-// 4) Add a test_case attribute for your new test to the reconstruct() function.
+// 3) Add a test_case macro invocation for your new test to the list right above that module.
 
 
-lazy_static! {
-    static ref MAP: HashMap<&'static str, fn() -> TOMLDocument<'static>> = {
-        let mut m = HashMap::new();
-        m.insert("empty", empty as fn() -> TOMLDocument<'static>);
-        m.insert("simple", simple as fn() -> TOMLDocument<'static>);
-        m.insert("AoTs", AoTs as fn() -> TOMLDocument<'static>);
-        m.insert("whitespace", whitespace as fn() -> TOMLDocument<'static>);
-        m.insert("indented", indented as fn() -> TOMLDocument<'static>);
-        m
+/// Defines a test case for the `reconstruction` test module. This macro takes
+/// three arguments:
+///
+/// 1. `$path`: A relative path from the Cargo package's root directory to the TOML file
+///    that should be parsed, and
+/// 2. `$function`: An identifier referring to the test function that will be called. The
+///    function must be defined with type `fn() -> TOMLDocument<'static>`, and it should
+///    **not** have the `#[test]` attribute. It should also be defined in the `constructors`
+///    module, and `constructors::` should be left off.
+/// 3. `$test_name`: An identifier that will be used as the test's name. Internally, it
+///    becomes the name of the function that does have the #[test] attribute.
+macro_rules! test_case {
+    ($path:expr, $function: ident; $test_name: ident) => {
+        #[test]
+        fn $test_name() {
+            reconstruct($path, constructors::$function);
+        }
     };
 }
 
-#[test_case("tests/reconstruction/empty.toml", "empty" :: "Empty")]
-#[test_case("tests/reconstruction/simple.toml", "simple" :: "Simple")]
-#[test_case("tests/reconstruction/AoTs.toml", "AoTs" :: "AoT's")]
-#[test_case("tests/reconstruction/whitespace.toml", "whitespace" :: "Whitespace")]
-#[test_case("tests/reconstruction/indented.toml", "indented" :: "Indented")]
+
+test_case!("tests/reconstruction/empty.toml", empty; Empty);
+test_case!("tests/reconstruction/simple.toml", simple; Simple);
+test_case!("tests/reconstruction/AoTs.toml", AoTs; AoTs);
+test_case!("tests/reconstruction/whitespace.toml", whitespace; Whitespace);
+test_case!("tests/reconstruction/indented.toml", indented; Indented);
+
+mod constructors {
+    use super::*;
+
+    pub fn empty() -> TOMLDocument<'static> {
+        let container = Container::new();
+        TOMLDocument(container)
+    }
+
+    pub fn simple() -> TOMLDocument<'static> {
+        let mut container = Container::new();
+        let trivia = Trivia::empty();
+
+        let bool_k = Key::new("bool");
+        let bool_v = Item::Bool {val: true, meta: trivia.clone()};
+        let _ = container.append(bool_k, bool_v);
+
+        let string_k = Key::new("string");
+        let string_v = Item::Str {
+            t: StringType::SLB,
+            val: "Hello!",
+            original: "Hello!",
+            meta: trivia.clone()
+        };
+        let _ = container.append(string_k, string_v);
+
+        let int_k = Key::new("int");
+        let int_v = Item::integer("42");
+        let _ = container.append(int_k, int_v);
+
+        TOMLDocument(container)
+    }
+
+    pub fn AoTs() -> TOMLDocument<'static> {
+        let mut container = Container::new();
+        let trivia = Trivia::empty();
+
+        let mut payload_first = Vec::new();
+
+        let first_1 = {
+            let mut _container = Container::new();
+            let id_k = Key::new("id");
+            let id_v = Item::integer("1");
+
+            let _ = _container.append(id_k, id_v);
+
+            let nested_id_k = Key::new("nested_id");
+            let nested_id_v = Item::integer("12");
+
+            let mut nested_container = Container::new();
+            let _ = nested_container.append(nested_id_k, nested_id_v);
+            let _ = nested_container.append(None, Item::WS(::NL));
+
+            let nested_k = Key::new("first.nested");
+            let nested_v = Item::Table {
+                is_array: false,
+                val: nested_container,
+                meta: trivia.clone(),
+            };
+
+            let _ = _container.append(nested_k, nested_v);
+
+            Item::Table {
+                is_array: true,
+                val: _container,
+                meta: trivia.clone(),
+            }
+        };
+
+        let first_2 = {
+            let mut _container = Container::new();
+            let id_k = Key::new("id");
+            let id_v = Item::integer("2");
+            let _ = _container.append(id_k, id_v);
+            let _ = _container.append(None, Item::WS(::NL));
+
+            Item::Table {
+                is_array: true,
+                val: _container,
+                meta: trivia.clone(),
+            }
+        };
+
+        let first_3 = {
+            let mut _container = Container::new();
+            let id_k = Key::new("id");
+            let id_v = Item::integer("3");
+            let _ = _container.append(id_k, id_v);
+
+            let nested_id_k = Key::new("nested_id");
+            let nested_id_v = Item::integer("31");
+
+            let mut _payload = Vec::new();
+
+            let boolean_k = Key::new("bool");
+            let boolean_v = Item::Bool {val: true, meta: trivia.clone()};
+            let mut table_container = Container::new();
+            let _ = table_container.append(boolean_k, boolean_v);
+            let _ = table_container.append(None, Item::WS(::NL));
+
+
+            let table = Item::Table {
+                is_array: true,
+                val: table_container,
+                meta: trivia.clone(),
+            };
+            _payload.push(table.clone());
+            _payload.push(table.clone());
+
+            let nestedagain_k = Key::new("first.nested.nestedagain");
+            let nestedagain_v = Item::AoT(_payload);
+
+            let mut nested_container = Container::new();
+            let _ = nested_container.append(nested_id_k, nested_id_v);
+            let _ = nested_container.append(nestedagain_k, nestedagain_v);
+
+            let nested_k = Key::new("first.nested");
+            let nested_v = Item::Table {
+                is_array: false,
+                val: nested_container,
+                meta: trivia.clone(),
+            };
+
+            let _ = _container.append(nested_k, nested_v);
+
+            Item::Table {
+                is_array: true,
+                val: _container,
+                meta: trivia.clone(),
+            }
+        };
+
+        payload_first.push(first_1);
+        payload_first.push(first_2);
+        payload_first.push(first_3);
+
+        let first_k = Key::new("first");
+        let first_v = Item::AoT(payload_first);
+
+        let mut payload_second = Vec::new();
+        let table = Item::Table {
+            is_array: true,
+            val: Container::new(),
+            meta: trivia.clone(),
+        };
+        payload_second.push(table.clone());
+        payload_second.push(table.clone());
+        payload_second.push(table.clone());    
+
+        let second_k = Key::new("second");
+        let second_v = Item::AoT(payload_second);
+
+
+        let _ = container.append(first_k, first_v);
+        let _ = container.append(second_k, second_v);
+        
+        TOMLDocument(container)
+    }
+
+    pub fn whitespace() -> TOMLDocument<'static> {
+        let mut container = Container::new();
+        let trivia = Trivia::empty();
+        let item = Item::WS(concat!(
+            "           ", nl!(),
+            "\t", nl!(),
+            nl!(),
+            "    ", nl!(),
+            "  \t    ", nl!()
+        ));
+        container.append(None, item).unwrap();
+        TOMLDocument(container)
+    }
+
+    pub fn indented() -> TOMLDocument<'static> {
+        let mut container = Container::new();
+
+        let mut trivia = Trivia::empty();
+        trivia.trail = concat!("  ", nl!());
+        let key = Key::new("bool");
+        let value = Item::Bool {val: true, meta: trivia};
+        container.append(key, value).unwrap();
+
+        let mut trivia = Trivia::empty();
+        trivia.indent = "\t";
+        trivia.trail = concat!("\t", nl!());
+        let key = Key::new("string");
+        let value = Item::Str {t: StringType::SLB, val: "Hello!", original: "Hello!", meta: trivia};
+        container.append(key, value).unwrap();
+
+        let trivia = Trivia::empty();
+        let value = Item::WS(concat!(nl!(), nl!()));
+        container.append(None, value).unwrap();
+
+        let mut trivia = Trivia::empty();
+        trivia.indent = " ";
+        let key = Key::new("int");
+        let value = Item::Integer {val: 42, meta: trivia, raw: "42"};
+        container.append(key, value).unwrap();
+
+        TOMLDocument(container)
+    }
+}
+
 /// Constructs a copy of the reference document using the API and 
 /// compares the two `TOMLDocument` hierarchies.
-fn reconstuct<P: AsRef<Path> + Display>(path: P, constructor: &str) {
+fn reconstruct<P: AsRef<Path> + Display>(path: P, under_test: fn() -> TOMLDocument<'static>) {
     let mut reference = String::new();
     let mut f = File::open(&path).unwrap();
     f.read_to_string(&mut reference).unwrap();
 
-    let under_test = MAP[constructor]();
     let parsed = {
         let mut parser = Molten::parser::Parser::new(&reference);
         parser.parse().unwrap()
     };
 
-    assert_eq!(reference, under_test.as_string());
-    assert_eq!(parsed, under_test);
+    let result = under_test();
+    assert_eq!(reference, result.as_string());
+    assert_eq!(parsed, result);
     
     let mut original = File::create("parsed.txt").unwrap();
     let mut reconstructed = File::create("reconstructed.txt").unwrap();
 
     let _ = original.write(format!("{:#?}", parsed).as_bytes()).unwrap();
     let _ = reconstructed.write(format!("{:#?}", under_test).as_bytes()).unwrap();
-}
-
-fn empty() -> TOMLDocument<'static> {
-    let container = Container::new();
-    TOMLDocument(container)
-}
-
-fn simple() -> TOMLDocument<'static> {
-    let mut container = Container::new();
-    let trivia = Trivia::empty();
-
-    let bool_k = Key::new("bool");
-    let bool_v = Item::Bool {val: true, meta: trivia.clone()};
-    let _ = container.append(bool_k, bool_v);
-
-    let string_k = Key::new("string");
-    let string_v = Item::Str {
-        t: StringType::SLB,
-        val: "Hello!",
-        original: "Hello!",
-        meta: trivia.clone()
-    };
-    let _ = container.append(string_k, string_v);
-
-    let int_k = Key::new("int");
-    let int_v = Item::integer("42");
-    let _ = container.append(int_k, int_v);
-
-    TOMLDocument(container)
-}
-
-fn AoTs() -> TOMLDocument<'static> {
-    let mut container = Container::new();
-    let trivia = Trivia::empty();
-
-    let mut payload_first = Vec::new();
-
-    let first_1 = {
-        let mut _container = Container::new();
-        let id_k = Key::new("id");
-        let id_v = Item::integer("1");
-        let _ = _container.append(id_k, id_v);
-
-        let nested_id_k = Key::new("nested_id");
-        let nested_id_v = Item::integer("12");
-
-        let mut nested_container = Container::new();
-        let _ = nested_container.append(nested_id_k, nested_id_v);
-        let _ = nested_container.append(None, Item::WS(::NL));
-
-        let nested_k = Key::new("first.nested");
-        let nested_v = Item::Table {
-            is_array: false,
-            val: nested_container,
-            meta: trivia.clone(),
-        };
-
-        let _ = _container.append(nested_k, nested_v);
-
-        Item::Table {
-            is_array: true,
-            val: _container,
-            meta: trivia.clone(),
-        }
-    };
-
-    let first_2 = {
-        let mut _container = Container::new();
-        let id_k = Key::new("id");
-        let id_v = Item::integer("2");
-        let _ = _container.append(id_k, id_v);
-        let _ = _container.append(None, Item::WS(::NL));
-
-        Item::Table {
-            is_array: true,
-            val: _container,
-            meta: trivia.clone(),
-        }
-    };
-
-    let first_3 = {
-        let mut _container = Container::new();
-        let id_k = Key::new("id");
-        let id_v = Item::integer("3");
-        let _ = _container.append(id_k, id_v);
-
-        let nested_id_k = Key::new("nested_id");
-        let nested_id_v = Item::integer("31");
-
-        let mut _payload = Vec::new();
-
-        let boolean_k = Key::new("bool");
-        let boolean_v = Item::Bool {val: true, meta: trivia.clone()};
-        let mut table_container = Container::new();
-        let _ = table_container.append(boolean_k, boolean_v);
-        let _ = table_container.append(None, Item::WS(::NL));
-
-
-        let table = Item::Table {
-            is_array: true,
-            val: table_container,
-            meta: trivia.clone(),
-        };
-        _payload.push(table.clone());
-        _payload.push(table.clone());
-
-        let nestedagain_k = Key::new("first.nested.nestedagain");
-        let nestedagain_v = Item::AoT(_payload);
-
-        let mut nested_container = Container::new();
-        let _ = nested_container.append(nested_id_k, nested_id_v);
-        let _ = nested_container.append(nestedagain_k, nestedagain_v);
-
-        let nested_k = Key::new("first.nested");
-        let nested_v = Item::Table {
-            is_array: false,
-            val: nested_container,
-            meta: trivia.clone(),
-        };
-
-        let _ = _container.append(nested_k, nested_v);
-
-        Item::Table {
-            is_array: true,
-            val: _container,
-            meta: trivia.clone(),
-        }
-    };
-
-    payload_first.push(first_1);
-    payload_first.push(first_2);
-    payload_first.push(first_3);
-    
-    let first_k = Key::new("first");
-    let first_v = Item::AoT(payload_first);
-
-    let mut payload_second = Vec::new();
-    let table = Item::Table {
-        is_array: true,
-        val: Container::new(),
-        meta: trivia.clone(),
-    };
-    payload_second.push(table.clone());
-    payload_second.push(table.clone());
-    payload_second.push(table.clone());    
-
-    let second_k = Key::new("second");
-    let second_v = Item::AoT(payload_second);
-
-
-    let _ = container.append(first_k, first_v);
-    let _ = container.append(second_k, second_v);
-    
-    TOMLDocument(container)
-}
-
-fn whitespace() -> TOMLDocument<'static> {
-    let mut container = Container::new();
-    let trivia = Trivia::empty();
-    let item = Item::WS(concat!(
-        "           ", nl!(),
-        "\t", nl!(),
-        nl!(),
-        "    ", nl!(),
-        "  \t    ", nl!()
-    ));
-    container.append(None, item).unwrap();
-    TOMLDocument(container)
-}
-
-fn indented() -> TOMLDocument<'static> {
-    let mut container = Container::new();
-
-    let mut trivia = Trivia::empty();
-    trivia.trail = concat!("  ", nl!());
-    let key = Key::new("bool");
-    let value = Item::Bool {val: true, meta: trivia};
-    container.append(key, value).unwrap();
-
-    let mut trivia = Trivia::empty();
-    trivia.indent = "\t";
-    trivia.trail = concat!("\t", nl!());
-    let key = Key::new("string");
-    let value = Item::Str {t: StringType::SLB, val: "Hello!", original: "Hello!", meta: trivia};
-    container.append(key, value).unwrap();
-
-    let trivia = Trivia::empty();
-    let value = Item::WS(concat!(nl!(), nl!()));
-    container.append(None, value).unwrap();
-
-    let mut trivia = Trivia::empty();
-    trivia.indent = " ";
-    let key = Key::new("int");
-    let value = Item::Integer {val: 42, meta: trivia, raw: "42"};
-    container.append(key, value).unwrap();
-
-    TOMLDocument(container)
 }

--- a/tests/reproduction.rs
+++ b/tests/reproduction.rs
@@ -1,8 +1,6 @@
-#![feature(proc_macro)]
 #![allow(non_snake_case)]
 
 extern crate Molten;
-extern crate test_case_derive;
 #[macro_use]
 extern crate pretty_assertions;
 
@@ -12,27 +10,43 @@ use std::path::Path;
 use std::fs::File;
 use std::fmt::Display;
 
-use test_case_derive::test_case;
-
 // To add a test case:
 // 1) Create reference target toml file in /reproduction.
-// 2) Add a matching test_case attribute to the reproduce() function below.
+// 2) Add a matching test_case macro invocation to the list below.
 
-#[test_case("tests/reproduction/full.toml" :: "Full")]
-#[test_case("tests/reproduction/integers.toml" :: "Integers")]
-#[test_case("tests/reproduction/floats.toml" :: "Floats")]
-#[test_case("tests/reproduction/bools.toml" :: "Bools")]
-#[test_case("tests/reproduction/arrays.toml" :: "Arrays")]
-#[test_case("tests/reproduction/comments.toml" :: "Comments")]
-#[test_case("tests/reproduction/inline_tables.toml" :: "Inline Tables")]
-#[test_case("tests/reproduction/strings.toml" :: "Strings")]
-#[test_case("tests/reproduction/tables.toml" :: "Tables")]
-#[test_case("tests/reproduction/AoTs.toml" :: "aot's")]
-#[test_case("tests/reproduction/empty.toml" :: "Empty")]
-#[test_case("tests/reproduction/whitespace.toml" :: "Whitespace")]
-#[test_case("tests/reproduction/AoT_simple.toml" :: "AoT - Simple")]
-#[test_case("tests/reproduction/quoted_keys.toml" :: "Quoted Keys")]
-#[test_case("tests/reproduction/kv_sep.toml" :: "Kv Separators")]
+
+/// Defines a test case for the `reproduction` test module. This macro takes
+/// two arguments:
+///
+/// 1. `$path`: A relative path from the Cargo package's root directory to the TOML file
+///    that should be parsed, and
+/// 2. `$test_name`: An identifier that will be used as the test's name. Internally, it
+///    becomes the name of the test function.
+macro_rules! test_case {
+    ($path:expr; $test_name:ident) => {
+        #[test]
+        fn $test_name() {
+            reproduce($path);
+        }
+    };
+}
+
+test_case!("tests/reproduction/full.toml"; Full);
+test_case!("tests/reproduction/integers.toml"; Integers);
+test_case!("tests/reproduction/floats.toml"; Floats);
+test_case!("tests/reproduction/bools.toml"; Bools);
+test_case!("tests/reproduction/arrays.toml"; Arrays);
+test_case!("tests/reproduction/comments.toml"; Comments);
+test_case!("tests/reproduction/inline_tables.toml"; Inline_Tables);
+test_case!("tests/reproduction/strings.toml"; Strings);
+test_case!("tests/reproduction/tables.toml"; Tables);
+test_case!("tests/reproduction/AoTs.toml"; AoTs);
+test_case!("tests/reproduction/empty.toml"; Empty);
+test_case!("tests/reproduction/whitespace.toml"; Whitespace);
+test_case!("tests/reproduction/AoT_simple.toml"; AoT_Simple);
+test_case!("tests/reproduction/quoted_keys.toml"; Quoted_Keys);
+test_case!("tests/reproduction/kv_sep.toml"; Kv_Separators);
+
 /// This tests the parser's correctness by parsing each of the
 /// above files and attempting to reproduce them from the parsed structure.
 /// Any difference between original and reproduction is a bug.


### PR DESCRIPTION
This PR fixes #36 by creating `macro_rules!` macros that do roughly the same thing as [`test-case-derive`](http://www.crates.io/crates/test-case-derive/)'s `#[test-case]` attributes do. The tests still look the same when run, and I've tried to keep the process of adding tests roughly the same as it was. I did get rid of the `HashMap` of test functions in `tests/reconstruction.rs`, since it's no longer needed, so one step has been removed.

I've also changed `.travis.yml` so that it runs the tests in all three channels (stable, beta, and nightly) but doesn't fail the whole build if nightly fails. So when the nightly compiler has incompatible changes, we'll be able to react to them but won't have to respond before doing anything else.