### PR TITLE
Improve consistency and maintainability.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -9,7 +9,7 @@ use chrono::DateTime as ChronoDateTime;
 pub fn integer(raw: &'static str) -> Result<Item<'static>> {
     Ok(Item::Integer {
         val: raw.parse::<i64>()?,
-        meta: Trivia::empty(),
+        trivia: Trivia::new(),
         raw: raw,
     })
 }
@@ -17,7 +17,7 @@ pub fn integer(raw: &'static str) -> Result<Item<'static>> {
 pub fn float(raw: &'static str) -> Result<Item<'static>> {
     Ok(Item::Float {
         val: raw.parse::<f64>()?,
-        meta: Trivia::empty(),
+        trivia: Trivia::new(),
         raw: raw,
     })
 }
@@ -25,14 +25,14 @@ pub fn float(raw: &'static str) -> Result<Item<'static>> {
 pub fn bool(raw: &'static str) -> Result<Item<'static>> {
     Ok(Item::Bool {
         val: raw.parse::<bool>()?,
-        meta: Trivia::empty(),
+        trivia: Trivia::new(),
     })
 }
 
 pub fn datetime(raw: &'static str) -> Result<Item<'static>> {
     Ok(Item::DateTime {
         val: ChronoDateTime::parse_from_rfc3339(raw)?,
-        meta: Trivia::empty(),
+        trivia: Trivia::new(),
         raw: raw,
     })
 }
@@ -41,7 +41,7 @@ pub fn array<'a>() -> Result<Item<'a>> {
     Ok(Item::Array {
         // @todo: Average length of toml arrays?
         val: Vec::with_capacity(10),
-        meta: Trivia::empty(),
+        trivia: Trivia::new(),
     })
 }
 
@@ -49,14 +49,14 @@ pub fn table<'a>() -> Item<'a> {
     Item::Table {
         is_aot_elem: false,
         val: Container::new(),
-        meta: Trivia::empty(),
+        trivia: Trivia::new(),
     }
 }
 
 pub fn inline_table<'a>() -> Item<'a> {
     Item::InlineTable {
         val: Container::new(),
-        meta: Trivia::empty(),
+        trivia: Trivia::new(),
     }
 }
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -65,13 +65,13 @@ impl<'a> Container<'a> {
                             false => ("[", "]"),
                         };
                         format!("{}{}{}{}{}{}{}{}",
-                        v.meta().indent,
+                        v.trivia().indent,
                         open,
                         k.unwrap().as_string(),
                         close,
-                        v.meta().comment_ws,
-                        v.meta().comment,
-                        v.meta().trail,
+                        v.trivia().comment_ws,
+                        v.trivia().comment,
+                        v.trivia().trail,
                         v.as_string(),)
                     }
                     Item::AoT(vec) => {
@@ -80,11 +80,11 @@ impl<'a> Container<'a> {
                         for table in vec {
                             buf.push_str(&format!(
                                 "{}[[{}]]{}{}{}",
-                                table.meta().indent,
+                                table.trivia().indent,
                                 key,
-                                table.meta().comment_ws,
-                                table.meta().comment,
-                                table.meta().trail
+                                table.trivia().comment_ws,
+                                table.trivia().comment,
+                                table.trivia().trail
                             ));
                             buf.push_str(&table.as_string());
                         }
@@ -94,13 +94,13 @@ impl<'a> Container<'a> {
                         let k = k.unwrap();
                         format!(
                             "{}{}{}{}{}{}{}",
-                            v.meta().indent,
+                            v.trivia().indent,
                             k.as_string(),
                             k.sep,
                             v.as_string(),
-                            v.meta().comment_ws,
-                            v.meta().comment,
-                            v.meta().trail
+                            v.trivia().comment_ws,
+                            v.trivia().comment,
+                            v.trivia().trail
                         )
                     }
                 }

--- a/tests/reconstruction.rs
+++ b/tests/reconstruction.rs
@@ -61,12 +61,12 @@ mod constructors {
 
     pub fn simple() -> Result<TOMLDocument<'static>> {
         let mut container = Container::new();
-        let trivia = Trivia::empty();
+        let trivia = Trivia::new();
 
         let bool_k = Key::new("bool");
         let bool_v = Item::Bool {
             val: true,
-            meta: trivia.clone(),
+            trivia: trivia.clone(),
         };
         let _ = container.append(bool_k, bool_v);
 
@@ -75,7 +75,7 @@ mod constructors {
             t: StringType::SLB,
             val: "Hello!",
             original: "Hello!",
-            meta: trivia.clone(),
+            trivia: trivia.clone(),
         };
         let _ = container.append(string_k, string_v);
 
@@ -88,7 +88,7 @@ mod constructors {
 
     pub fn AoTs() -> Result<TOMLDocument<'static>> {
         let mut container = Container::new();
-        let trivia = Trivia::empty();
+        let trivia = Trivia::new();
 
         let mut payload_first = Vec::new();
 
@@ -110,7 +110,7 @@ mod constructors {
             let nested_v = Item::Table {
                 is_aot_elem: false,
                 val: nested_container,
-                meta: trivia.clone(),
+                trivia: trivia.clone(),
             };
 
             let _ = _container.append(nested_k, nested_v);
@@ -118,7 +118,7 @@ mod constructors {
             Item::Table {
                 is_aot_elem: true,
                 val: _container,
-                meta: trivia.clone(),
+                trivia: trivia.clone(),
             }
         };
 
@@ -132,7 +132,7 @@ mod constructors {
             Item::Table {
                 is_aot_elem: true,
                 val: _container,
-                meta: trivia.clone(),
+                trivia: trivia.clone(),
             }
         };
 
@@ -150,7 +150,7 @@ mod constructors {
             let boolean_k = Key::new("bool");
             let boolean_v = Item::Bool {
                 val: true,
-                meta: trivia.clone(),
+                trivia: trivia.clone(),
             };
             let mut table_container = Container::new();
             let _ = table_container.append(boolean_k, boolean_v);
@@ -160,7 +160,7 @@ mod constructors {
             let table = Item::Table {
                 is_aot_elem: true,
                 val: table_container,
-                meta: trivia.clone(),
+                trivia: trivia.clone(),
             };
             _payload.push(table.clone());
             _payload.push(table.clone());
@@ -176,7 +176,7 @@ mod constructors {
             let nested_v = Item::Table {
                 is_aot_elem: false,
                 val: nested_container,
-                meta: trivia.clone(),
+                trivia: trivia.clone(),
             };
 
             let _ = _container.append(nested_k, nested_v);
@@ -184,7 +184,7 @@ mod constructors {
             Item::Table {
                 is_aot_elem: true,
                 val: _container,
-                meta: trivia.clone(),
+                trivia: trivia.clone(),
             }
         };
 
@@ -199,7 +199,7 @@ mod constructors {
         let table = Item::Table {
             is_aot_elem: true,
             val: Container::new(),
-            meta: trivia.clone(),
+            trivia: trivia.clone(),
         };
         payload_second.push(table.clone());
         payload_second.push(table.clone());
@@ -217,7 +217,7 @@ mod constructors {
 
     pub fn whitespace() -> Result<TOMLDocument<'static>> {
         let mut container = Container::new();
-        let _trivia = Trivia::empty();
+        let _trivia = Trivia::new();
         let item = Item::WS(concat!(
             "           ",
             nl!(),
@@ -236,16 +236,16 @@ mod constructors {
     pub fn indented() -> Result<TOMLDocument<'static>> {
         let mut container = Container::new();
 
-        let mut trivia = Trivia::empty();
+        let mut trivia = Trivia::new();
         trivia.trail = concat!("  ", nl!());
         let key = Key::new("bool");
         let value = Item::Bool {
             val: true,
-            meta: trivia,
+            trivia: trivia,
         };
         container.append(key, value).unwrap();
 
-        let mut trivia = Trivia::empty();
+        let mut trivia = Trivia::new();
         trivia.indent = "\t";
         trivia.trail = concat!("\t", nl!());
         let key = Key::new("string");
@@ -253,20 +253,20 @@ mod constructors {
             t: StringType::SLB,
             val: "Hello!",
             original: "Hello!",
-            meta: trivia,
+            trivia: trivia,
         };
         container.append(key, value).unwrap();
 
-        let _trivia = Trivia::empty();
+        let _trivia = Trivia::new();
         let value = Item::WS(concat!(nl!(), nl!()));
         container.append(None, value).unwrap();
 
-        let mut trivia = Trivia::empty();
+        let mut trivia = Trivia::new();
         trivia.indent = " ";
         let key = Key::new("int");
         let value = Item::Integer {
             val: 42,
-            meta: trivia,
+            trivia: trivia,
             raw: "42",
         };
         container.append(key, value).unwrap();


### PR DESCRIPTION
Changes to make the codebase more consistent:
 - Changed StringType::empty() to StringType::new()
 - Changed name of 'meta' field in Items to 'trivia'
 - Changed Item::meta() to Item::trivia()
 - Changed Item::meta_mut() to Item::trivia_mut()
 - Add Parser::inc_n() to eliminate multiple Parser::inc() calls

Make working with Key and StringType delimiters easier:
 - Add function KeyType::delimiter() and tests
 - Add function StringType::delimiter(s: &StringType) and tests