### PR TITLE
Add unit tests for public API.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["LeopoldArkham <leopold.arkham@gmail.com>"]
 readme = "README.md"
 repository = "https://github.com/LeopoldArkham/Molten"
 homepage = "https://github.com/LeopoldArkham/Molten"
+documentation = "https://docs.rs/molten"
 description = """
 Molten is a lossless TOML parser that preserves all comments, indentations, 
 whitespace and internal element ordering, and makes all of these fully 
@@ -14,8 +15,12 @@ functionality to Cargo itself.
 """
 categories = ["config", "encoding", "parser-implementations"]
 
+# Set to true to enable publishing to crates.io
+publish = false
+
 [badges]
 travis-ci = { repository = "LeopoldArkham/Molten" }
+appveyor = { repository = "LeopoldArkham/Molten" }
 
 [features]
 nightly = ["criterion"]
@@ -25,7 +30,4 @@ chrono = "0.3.0"
 pretty_assertions = "0.4.0"
 error-chain = "0.11.0"
 criterion = { version = "0.1.0", optional = true }
-
-[dev-dependencies]
-pretty_assertions = "0.4.0"
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Molten
 
 [![Build Status](https://travis-ci.org/LeopoldArkham/Molten.svg?branch=master)](https://travis-ci.org/LeopoldArkham/Molten)
+[![Windows build status](https://ci.appveyor.com/api/projects/status/github/LeopoldArkham/Molten?svg=true)](https://ci.appveyor.com/project/LeopoldArkham/Molten)
 
-## [WIP] Molten - Style-preserving TOML parser.
+## [WIP] Molten - Style-preserving TOML parser
 
 Molten is a WIP lossless [TOML](https://github.com/toml-lang/toml) parser that preserves all
 comments, indentations, whitespace and internal element ordering, and makes all of these fully
@@ -11,27 +12,27 @@ used in [cargo-edit](https://github.com/killercup/cargo-edit), and, eventually, 
 functionality to Cargo itself.
 
 ### Goals
+
 - Speed: Molten is a one-pass parser which avoids allocation.
 - Unopinionated: Molten respects the way you wrote your document, to the letter.
 - Fully addressable: All TOML elements can be edited, created, or deleted via the API.
 - Strong API: The API does not let you create an invalid TOML file.
 
 ### Non-Goals
+
 - Error recovery: Molten does not try to correct recoverable errors.
 - Serde support: See [toml-rs](https://github.com/alexcrichton/toml-rs) for this.
 
-# License
+## License
 
 This project is licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
-   http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-   http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+- MIT license ([LICENSE-MIT](LICENSE-MIT))
 
 at your option.
 
-### Contribution
+## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in Molten by you, as defined in the Apache-2.0 license, shall be

--- a/src/api.rs
+++ b/src/api.rs
@@ -53,25 +53,25 @@ pub fn array<'a>() -> Result<Item<'a>> {
 }
 
 /// Return a table `Item` parsed from the text `str`.
-pub fn table<'a>() -> Item<'a> {
-    Item::Table {
+pub fn table<'a>() -> Result<Item<'a>> {
+    Ok(Item::Table {
         is_aot_elem: false,
         val: Container::new(),
         trivia: Trivia::new(),
-    }
+    })
 }
 
 /// Return an inline table `Item` parsed from the text `str`.
-pub fn inline_table<'a>() -> Item<'a> {
-    Item::InlineTable {
+pub fn inline_table<'a>() -> Result<Item<'a>> {
+    Ok(Item::InlineTable {
         val: Container::new(),
         trivia: Trivia::new(),
-    }
+    })
 }
 
 /// Return an aot `Item` parsed from the text `str`.
-pub fn aot<'a>() -> Item<'a> {
-    Item::AoT(Vec::with_capacity(5))
+pub fn aot<'a>() -> Result<Item<'a>> {
+    Ok(Item::AoT(Vec::with_capacity(5)))
 }
 
 /// Return a value `Item` parsed from the text `str`.
@@ -108,18 +108,18 @@ pub fn string<'a>(raw: &'a str) -> Result<Item<'a>> {
 
 /// Append - Remove
 impl<'a> Item<'a> {
-    /// Append a (key, value) to the current `Item`.
-    pub fn append<K: Into<Option<Key<'a>>>>(&mut self, _key: K, item: Item<'a>) -> Result<()> {
+    /// Append a (key, value) to the current table.
+    pub fn append<K: Into<Option<Key<'a>>>>(&mut self, key: K, item: Item<'a>) -> Result<()> {
         use Item::*;
         match *self {
             Table { ref mut val, .. } |
-            InlineTable { ref mut val, .. } => val.append(_key, item),
+            InlineTable { ref mut val, .. } => val.append(key, item),
             Array { .. } | AoT { .. } => unimplemented!(),
             _ => bail!(ErrorKind::APIWrongItem),
         }
     }
 
-    /// Remove the value for the key `key` from the current `Item`.
+    /// Remove the (key, value) `key` from the current table.
     pub fn remove(&mut self, key: &Key<'a>) -> Result<()> {
         use Item::*;
         match *self {
@@ -172,7 +172,7 @@ impl<'a> Item<'a> {
     }
 
     /// Returns true if Item is a date/time.
-    pub fn is_date_time(&self) -> bool {
+    pub fn is_datetime(&self) -> bool {
         self.discriminant() == 5
     }
 
@@ -204,5 +204,167 @@ impl<'a> Item<'a> {
     /// Returns true if Item is None.
     pub fn is_none(&self) -> bool {
         self.discriminant() == 11
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_integer() {
+        // tests contains tuples of a string to test and a boolean that
+        // indicates whether the result of parsing that string should be valid
+        // (true), or not (false).
+        let tests = vec![("99572", true), ("37.2", false)];
+        for (v, r) in tests {
+            let i = integer(v);
+            if r {
+                assert!(i.is_ok());
+                assert!(i.unwrap().is_integer());
+            } else {
+                assert!(i.is_err());
+            }
+        }
+    }
+
+    #[test]
+    fn api_float() {
+        // tests contains tuples of a string to test and a boolean that
+        // indicates whether the result of parsing that string should be valid
+        // (true), or not (false).
+        let tests = vec![("39581.102", true), ("12577.2", true), ("385", true)];
+        for (v, r) in tests {
+            let i = float(v);
+            if r {
+                assert!(i.is_ok());
+                assert!(i.unwrap().is_float());
+            } else {
+                assert!(i.is_err());
+            }
+        }
+    }
+
+    #[test]
+    fn api_bool() {
+        // tests contains tuples of a string to test and a boolean that
+        // indicates whether the result of parsing that string should be valid
+        // (true), or not (false).
+        let tests = vec![("true", true), ("false", true), ("blarg", false)];
+        for (v, r) in tests {
+            let i = bool(v);
+            if r {
+                assert!(i.is_ok());
+                assert!(i.unwrap().is_bool());
+            } else {
+                assert!(i.is_err());
+            }
+        }
+    }
+
+    #[test]
+    fn api_string() {
+        // tests contains tuples of a string to test and a boolean that
+        // indicates whether the result of parsing that string should be valid
+        // (true), or not (false).
+        let tests = vec![
+            ("'my string'", true),
+            ("\"My string\"", true),
+            ("'1234'", true),
+        ];
+
+        for (v, r) in tests {
+            let i = string(v);
+            if r {
+                assert!(i.is_ok());
+                assert!(i.unwrap().is_string());
+            } else {
+                assert!(i.is_err());
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    /// Datetimes are [RFC-3339](https://tools.ietf.org/html/rfc3339)-compliant
+    /// date or time strings.
+
+    // BUG(markcol): fix parsing problems with date times. According to the
+    // [TOML spec](https://github.com/toml-lang/toml#user-content-local-date),
+    // the tests below should work, but fail.
+    fn api_datetime() {
+        // tests contains tuples of a string to test and a boolean that
+        // indicates whether the result of parsing that string should be valid
+        // (true), or not (false).
+        let tests = vec![("1979-05-20", true), ("1974-5-20T11:05Z", true)];
+        for (v, r) in tests {
+            let i = datetime(v);
+            if r {
+                assert!(i.is_ok());
+                assert!(i.unwrap().is_datetime());
+            } else {
+                assert!(i.is_err());
+            }
+        }
+    }
+
+    #[test]
+    fn api_array() {
+        let i = array();
+        assert!(i.is_ok());
+        assert!(i.unwrap().is_array());
+
+        // TODO(markcol): add tests for append/remove
+    }
+
+    #[test]
+    fn api_table() {
+        let i = table();
+        assert!(i.is_ok());
+        assert!(i.unwrap().is_table());
+
+        // TODO(markcol): add tests for append/remove
+        // assert!(i.append("key1", string("\"some string\"").unwrap()).is_ok());
+        // assert!(i.append("key2", integer("123").unwrap()).is_ok());
+    }
+
+    #[test]
+    fn api_inline_table() {
+        let i = inline_table();
+        assert!(i.is_ok());
+        assert!(i.unwrap().is_inline_table());
+
+        // TODO(markcol): add tests for append/remove
+    }
+
+    #[test]
+    #[ignore]
+    fn api_is_trivia() {
+        unimplemented!();
+    }
+
+    #[test]
+    #[ignore]
+    fn api_is_value() {
+        unimplemented!();
+    }
+
+    #[test]
+    #[ignore]
+    fn api_is_ws() {
+        unimplemented!();
+    }
+
+    #[test]
+    #[ignore]
+    fn api_is_comment() {
+        unimplemented!();
+    }
+
+    #[test]
+    #[ignore]
+    fn api_is_none() {
+        unimplemented!();
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -209,6 +209,7 @@ impl<'a> Item<'a> {
 
 
 #[cfg(test)]
+#[allow(unused_mut)]
 mod tests {
     use super::*;
 
@@ -313,29 +314,38 @@ mod tests {
     fn api_array() {
         let i = array();
         assert!(i.is_ok());
-        assert!(i.unwrap().is_array());
-
+        let mut item = i.unwrap();
+        assert!(item.is_array());
         // TODO(markcol): add tests for append/remove
     }
 
+    #[allow(unused_mut)]
     #[test]
     fn api_table() {
         let i = table();
         assert!(i.is_ok());
-        assert!(i.unwrap().is_table());
-
-        // TODO(markcol): add tests for append/remove
-        // assert!(i.append("key1", string("\"some string\"").unwrap()).is_ok());
-        // assert!(i.append("key2", integer("123").unwrap()).is_ok());
+        let mut item = i.unwrap();
+        assert!(item.is_table());
+        let key = "Key1";
+        let s = "'my string'";
+        assert!(item.append(Key::new(key), string(s).unwrap()).is_ok());
+        assert_eq!(&item[key].as_string(), s);
+        assert!(item.remove(&Key::new(key)).is_ok());
+        assert_eq!(&item[key].as_string(), "");
     }
 
     #[test]
     fn api_inline_table() {
         let i = inline_table();
         assert!(i.is_ok());
-        assert!(i.unwrap().is_inline_table());
-
-        // TODO(markcol): add tests for append/remove
+        let mut item = i.unwrap();
+        assert!(item.is_inline_table());
+        let key = "Key1";
+        let s = "'my string'";
+        assert!(item.append(Key::new(key), string(s).unwrap()).is_ok());
+        assert_eq!(&item[key].as_string(), s);
+        assert!(item.remove(&Key::new(key)).is_ok());
+        assert_eq!(&item[key].as_string(), "");
     }
 
     #[test]


### PR DESCRIPTION
Add unit tests for public API. Other minor changes to the API:

- Changed name of `is_date_time` to `is_datetime` to be consistent with spelling of datetime
- Changed `table`, `inline_table`, and `array` to return `Result<Item<'a>>` rather than `Item<'a>`