### PR TITLE
Add appveyor.yml to enable Continuous Integration tests on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,61 @@
+environment:
+
+  global:
+    RUST_VERSION: stable
+    
+  matrix:
+    # MSVC
+    - TARGET: x86_64-pc-windows-msvc
+    - TARGET: i686-pc-windows-msvc
+
+    # MinGW
+    - TARGET: x86_64-pc-windows-gnu
+    - TARGET: i686-pc-windows-gnu
+
+    # Nightly
+    - TARGET: i686-pc-windows-msvc
+      RUST_VERSION: nightly
+    - TARGET: x86_64-pc-windows-gnu
+      RUST_VERSION: nightly
+
+    # Beta
+    - TARGET: i686-pc-windows-msvc
+      RUST_VERSION: beta
+    - TARGET: x86_64-pc-windows-gnu
+      RUST_VERSION: beta
+
+  
+install:
+  - ps: >-
+      If ($Env:TARGET -eq 'x86_64-pc-windows-gnu') {
+        $Env:PATH += ';C:\msys64\mingw64\bin'
+      } ElseIf ($Env:TARGET -eq 'i686-pc-windows-gnu') {
+        $Env:PATH += ';C:\msys64\mingw32\bin'
+      }
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -Vv
+  - cargo -V
+
+test_script:
+  - cargo build --verbose
+  - cargo test --verbose
+  - rustdoc --test README.md -L target
+  - cargo doc --no-deps || echo "skipping cargo doc"
+
+build: off
+
+cache:
+  - C:\Users\appveyor\.cargo\registry
+  - target
+
+branches:
+  only:
+    # Release tags
+    - /^v\d+\.\d+\.\d+.*$/
+    - master
+
+notifications:
+  - provider: Email
+    on_build_success: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,42 +1,36 @@
 environment:
-
-  global:
-    RUST_VERSION: stable
-    
   matrix:
-    # MSVC
     - TARGET: x86_64-pc-windows-msvc
+      RUST: stable
     - TARGET: i686-pc-windows-msvc
-
-    # MinGW
+      RUST: stable
     - TARGET: x86_64-pc-windows-gnu
+      RUST: stable
     - TARGET: i686-pc-windows-gnu
-
-    # Nightly
+      RUST: stable
+    - TARGET: x86_64-pc-windows-msvc
+      RUST: nightly
     - TARGET: i686-pc-windows-msvc
-      RUST_VERSION: nightly
+      RUST: nightly
     - TARGET: x86_64-pc-windows-gnu
-      RUST_VERSION: nightly
-
-    # Beta
+      RUST: nightly
+    - TARGET: i686-pc-windows-gnu
+      RUST: nightly
+    - TARGET: x86_64-pc-windows-msvc
+      RUST: beta
     - TARGET: i686-pc-windows-msvc
-      RUST_VERSION: beta
+      RUST: beta
     - TARGET: x86_64-pc-windows-gnu
-      RUST_VERSION: beta
-
+      RUST: beta
+    - TARGET: i686-pc-windows-gnu
+      RUST: beta
   
 install:
-  - ps: >-
-      If ($Env:TARGET -eq 'x86_64-pc-windows-gnu') {
-        $Env:PATH += ';C:\msys64\mingw64\bin'
-      } ElseIf ($Env:TARGET -eq 'i686-pc-windows-gnu') {
-        $Env:PATH += ';C:\msys64\mingw32\bin'
-      }
-  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
-  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
-  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs
+  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST%
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - rustc -Vv
-  - cargo -V
+  - cargo -Vv
 
 test_script:
   - cargo build --verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,10 +45,10 @@ cache:
   - target
 
 branches:
-  only:
-    # Release tags
-    - /^v\d+\.\d+\.\d+.*$/
-    - master
+#  only:
+#    # Release tags
+#    - /^v\d+\.\d+\.\d+.*$/
+#    - master
 
 notifications:
   - provider: Email

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,11 +44,11 @@ cache:
   - C:\Users\appveyor\.cargo\registry
   - target
 
-# branches:
-#  only:
-#    # Release tags
-#    - /^v\d+\.\d+\.\d+.*$/
-#    - master
+branches:
+  only:
+    # Release tags
+    - /^v\d+\.\d+\.\d+.*$/
+    - master
 
 notifications:
   - provider: Email

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ cache:
   - C:\Users\appveyor\.cargo\registry
   - target
 
-branches:
+# branches:
 #  only:
 #    # Release tags
 #    - /^v\d+\.\d+\.\d+.*$/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-/*! 
-Molten is a lossless TOML parser that preserves all comments, indentations, 
-whitespace and internal element ordering, and makes all of these fully 
-editable via an easy API. It is written with the intent of replacing the 
+/*!
+Molten is a lossless TOML parser that preserves all comments, indentations,
+whitespace and internal element ordering, and makes all of these fully
+editable via an easy API. It is written with the intent of replacing the
 current TOML parser used in [cargo-edit](https://github.com/killercup/cargo-edit),
-and, eventually, adding that functionality to 
+and, eventually, adding that functionality to
 [cargo](https://github.com/rust-lang/cargo) itself.
 
 ## Goals
@@ -85,7 +85,7 @@ pub use container::Container;
 #[macro_export]
 #[cfg(windows)]
 macro_rules! nl {
-    () => {"\r\n"};
+    () => {"\n"};
 }
 
 #[doc(hide)]


### PR DESCRIPTION
The appveyor.yml config allows testing of code on Windows. This will require setting up an account on Appveyor, which is quite simple.

The test matrix for Windows testing is more complex than for Unix-like environments because there are two different Rust runtimes for Windows depending on which compiler toolchain is to be used: MSVC or GNU, and 32- and 64-bit versions of each of them.

The appveyor tests only run on the master branch of the git repository, or for tagged releases. This can be changed in the `branches:` configuration stanza.

Change the Windows line terminator sequence from '\r\n' to '\n' because the previous definition caused the tests to fail.

